### PR TITLE
Rename bridging protocol

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -9,10 +9,6 @@
 import SwiftUI
 import CocoaUI
 
-extension Text: CocoaViewControllerBridging {
-    public typealias DefaultCocoaControllerType = CocoaViewController
-}
-
 struct ContentView: View {
     @State var value: Float = 0
     @State var toggle: Bool = true
@@ -39,7 +35,7 @@ struct ContentView: View {
                         ForEach(0..<100) { i in
                             NavigationLink {
                                 Text("data \(i)")
-                                    .cocoa { vc in
+                                    .cocoa(for: CocoaViewController.self) { vc in
                                         print(vc)
                                     }
                                     .onViewWillAppear { vc in
@@ -48,6 +44,7 @@ struct ContentView: View {
                                     .onViewWillDisappear { vc in
                                         vc?.tabBarController?.tabBar.isHidden = false
                                     }
+                                    .background(Color.cyan)
                             } label: {
                                 Text("data \(i)")
                             }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Therefore, it can be customized by directly referencing the UISlider object as f
 ![Slider](https://user-images.githubusercontent.com/50244599/229353608-86eb9a3c-815e-4919-9f44-1cc35d244d7e.png)
 
 ## Document
-For components conforming to the protocol named `CocoaViewBridging`, you can get UIKit/Cocoa objects as follows.
+For components conforming to the protocol named `DefaultCocoaViewBridging`, you can get UIKit/Cocoa objects as follows.
+`DefaultCocoaViewBridging` gets the UIView object from SwiftUI.View.
+In contrast, `DefaultCocoaControllerBridging` gets the UIViewController object.
 </br>
 The CocoaBriding protocol defines a `DefaultCocoaType`.　　
 For example, for Toggle, the DefaultCocoaType is UISwitch(iOS).　　
@@ -44,16 +46,16 @@ Toggle("Hello", isOn: .constant(true))
        button.layer.borderWidth = 1
     }
 ```
-
+The method of specifying the type is defined in SwiftUI.View's and does not need to conform to the `DefaultCocoaViewBridging` or `DefaultCocoaControllerBridging ` protocols.
 If the specified type is not found, the closure will not be called.
 
 ### Support additional component
 ```swift
-extension XXView: CocoaViewBridging { // confirms `CocoaViewBridging`
+extension XXView: DefaultCocoaViewBridging { // confirms `DefaultCocoaViewBridging`
     public typealias DefaultCocoaViewType = XXCocoaView // UIKit/Cocoa type
 }
 
-extension YYView: CocoaViewControllerBridging { // confirms `CocoaViewControllerBridging`
+extension YYView: DefaultCocoaViewControllerBridging { // confirms `DefaultCocoaViewControllerBridging`
     public typealias DefaultCocoaControllerType = YYCocoaViewController // UIKit/Cocoa type
 }
 ```

--- a/Sources/CocoaUI/CocoaBridging.swift
+++ b/Sources/CocoaUI/CocoaBridging.swift
@@ -8,30 +8,24 @@
 
 import SwiftUI
 
-public protocol CocoaViewBridging: SwiftUI.View {
+// MARK: View ⇄ CocoaView
+public protocol DefaultCocoaViewBridging: SwiftUI.View {
     associatedtype DefaultCocoaViewType: CocoaView
 }
 
-extension CocoaViewBridging {
+extension DefaultCocoaViewBridging {
     public func cocoa(_ handler: @escaping ((DefaultCocoaViewType) -> Void)) -> CocoaBridgeView<Self, DefaultCocoaViewType> {
         CocoaBridgeView(self, customize: handler)
     }
-
-    public func cocoa<T: CocoaView>(for type: T.Type, _ handler: @escaping ((T) -> Void)) -> CocoaBridgeView<Self, T> {
-        CocoaBridgeView(self, customize: handler)
-    }
 }
 
-public protocol CocoaViewControllerBridging: SwiftUI.View {
+// MARK: View ⇄ CocoaViewController
+public protocol DefaultCocoaViewControllerBridging: SwiftUI.View  {
     associatedtype DefaultCocoaControllerType: CocoaViewController
 }
 
-extension CocoaViewControllerBridging {
+extension DefaultCocoaViewControllerBridging {
     public func cocoa(_ handler: @escaping ((DefaultCocoaControllerType) -> Void)) -> CocoaBridgeView<Self, DefaultCocoaControllerType> {
-        CocoaBridgeView(self, customize: handler)
-    }
-
-    public func cocoa<T: CocoaViewController>(for type: T.Type, _ handler: @escaping ((T) -> Void)) -> CocoaBridgeView<Self, T> {
         CocoaBridgeView(self, customize: handler)
     }
 }

--- a/Sources/CocoaUI/CocoaUI.swift
+++ b/Sources/CocoaUI/CocoaUI.swift
@@ -1,10 +1,20 @@
 import SwiftUI
 
-extension ScrollView: CocoaViewBridging {
+extension View {
+    public func cocoa<T: CocoaView>(for type: T.Type, _ handler: @escaping ((T) -> Void)) -> CocoaBridgeView<Self, T> {
+        CocoaBridgeView(self, customize: handler)
+    }
+
+    public func cocoa<T: CocoaViewController>(for type: T.Type, _ handler: @escaping ((T) -> Void)) -> CocoaBridgeView<Self, T> {
+        CocoaBridgeView(self, customize: handler)
+    }
+}
+
+extension ScrollView: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaScrollView
 }
 
-extension List: CocoaViewBridging {
+extension List: DefaultCocoaViewBridging {
     #if canImport(UIKit)
     /// NOTE: Definition for iOS 16 or later
     /// < iOS16 `UITableView`
@@ -17,7 +27,7 @@ extension List: CocoaViewBridging {
 @available(iOS 14.0, *)
 @available(macOS 11.0, *)
 @available(tvOS 14.0, *)
-extension ProgressView: CocoaViewBridging {
+extension ProgressView: DefaultCocoaViewBridging {
 #if canImport(UIKit)
     public typealias DefaultCocoaViewType = UIProgressView
 #elseif canImport(Cocoa)
@@ -26,15 +36,15 @@ extension ProgressView: CocoaViewBridging {
 }
 
 
-extension TextField: CocoaViewBridging {
+extension TextField: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaTextField
 }
 
-extension SecureField: CocoaViewBridging {
+extension SecureField: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaTextField
 }
 
-extension Picker: CocoaViewBridging {
+extension Picker: DefaultCocoaViewBridging {
 #if canImport(UIKit) && os(iOS)
     public typealias DefaultCocoaViewType = UIPickerView
 #elseif canImport(Cocoa)
@@ -46,7 +56,7 @@ extension Picker: CocoaViewBridging {
 
 // MARK: - iOS and tvOS only
 #if os(iOS) || os(tvOS)
-extension Form: CocoaViewBridging {
+extension Form: DefaultCocoaViewBridging {
 #if os(iOS)
     /// NOTE: Definition for iOS 16 or later
     /// < iOS16 `UITableView`
@@ -59,25 +69,25 @@ extension Form: CocoaViewBridging {
 
 // MARK: - macOS and iOS only
 #if os(iOS) || os(macOS)
-extension Slider: CocoaViewBridging {
+extension Slider: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaSlider
 }
 
-extension Stepper: CocoaViewBridging {
+extension Stepper: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaStepper
 }
 
-extension DatePicker: CocoaViewBridging {
+extension DatePicker: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaDatePicker
 }
 
 @available(iOS 14.0, *)
 @available(macOS 11.0, *)
-extension ColorPicker: CocoaViewBridging {
+extension ColorPicker: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaColorWell
 }
 
-extension Toggle: CocoaViewBridging {
+extension Toggle: DefaultCocoaViewBridging {
     /// NOTE: Depending on the `ToggleStyle`, Cocoa types are different.
 #if canImport(UIKit)
     public typealias DefaultCocoaViewType = UISwitch
@@ -88,7 +98,7 @@ extension Toggle: CocoaViewBridging {
 
 @available(iOS 14.0, *)
 @available(macOS 11.0, *)
-extension TextEditor: CocoaViewBridging {
+extension TextEditor: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = CocoaTextView
 }
 #endif
@@ -96,51 +106,51 @@ extension TextEditor: CocoaViewBridging {
 // MARK: - iOS only
 #if os(iOS)
 @available(iOS 16.0, *)
-extension MultiDatePicker: CocoaViewBridging {
+extension MultiDatePicker: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = UICalendarView
 }
 #endif
 
 // MARK: - macOS only
 #if os(macOS) && canImport(Cocoa)
-extension Button: CocoaViewBridging {
+extension Button: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = NSButton
 }
 #endif
 
 // MARK: - Tab and Navigation
 #if canImport(UIKit)
-extension TabView: CocoaViewControllerBridging {
+extension TabView: DefaultCocoaViewControllerBridging {
     public typealias DefaultCocoaControllerType = UITabBarController
 }
 #elseif canImport(Cocoa)
-extension TabView: CocoaViewBridging {
+extension TabView: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = NSTabView
 }
 #endif
 
 #if canImport(UIKit) && os(iOS)
-extension NavigationView: CocoaViewControllerBridging {
+extension NavigationView: DefaultCocoaViewControllerBridging {
     public typealias DefaultCocoaControllerType = UISplitViewController
 }
 #elseif canImport(Cocoa)
-extension NavigationView: CocoaViewBridging {
+extension NavigationView: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = NSSplitView
 }
 #elseif canImport(UIKit) && os(tvOS)
-extension NavigationView: CocoaViewControllerBridging {
+extension NavigationView: DefaultCocoaViewControllerBridging {
     public typealias DefaultCocoaViewType = UINavigationController
 }
 #endif
 
 #if canImport(UIKit)
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-extension NavigationStack: CocoaViewControllerBridging {
+extension NavigationStack: DefaultCocoaViewControllerBridging {
     public typealias DefaultCocoaControllerType = UINavigationController
 }
 #elseif canImport(Cocoa)
 //@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-//extension NavigationStack: CocoaViewBridging {
+//extension NavigationStack: DefaultCocoaViewBridging {
 //    public typealias DefaultCocoaType = CocoaView
 //}
 #endif
@@ -148,12 +158,12 @@ extension NavigationStack: CocoaViewControllerBridging {
 #if os(iOS) || os(macOS)
 #if canImport(UIKit)
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-extension NavigationSplitView: CocoaViewControllerBridging {
+extension NavigationSplitView: DefaultCocoaViewControllerBridging {
     public typealias DefaultCocoaControllerType = UISplitViewController
 }
 #elseif canImport(Cocoa)
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-extension NavigationSplitView: CocoaViewBridging {
+extension NavigationSplitView: DefaultCocoaViewBridging {
     public typealias DefaultCocoaViewType = NSSplitView
 }
 #endif


### PR DESCRIPTION
SwiftUI.View now has a `.cocoa(for:)` method by default.